### PR TITLE
Fix order of operations for special case of depressed cubic

### DIFF
--- a/Python/quartic.py
+++ b/Python/quartic.py
@@ -88,7 +88,7 @@ def sqrts(x):
 def solveDepressedCubic(q, p):
     thirdRootUnity = math.e**(math.pi/3j)
     if p == 0:
-        r = -q ** 1/3.
+        r = -q ** (1/3.)
     else:
         u = solvePoly([-p*p*p/27, q, 1])[0]**(1/3.)
         r = u - p/3/u


### PR DESCRIPTION
There is an important difference here.

```python
[ins] In [4]: -4 ** 1/3
Out[4]: -1.3333333333333333

[ins] In [5]: -4 ** (1/3)
Out[5]: -1.5874010519681994
```